### PR TITLE
Add pre-commit hook configuration

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 - id: sort
   name: Check Cargo.toml is sorted
   description: 'Ensure Cargo.toml is sorted'
-  entry: cargo-sort -c -w
+  entry: cargo-sort
   language: rust
   types: [file, toml]
   files: Cargo\.toml

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,4 +1,4 @@
-- id: sort
+- id: cargo-sort
   name: Check Cargo.toml is sorted
   description: 'Ensure Cargo.toml is sorted'
   entry: cargo-sort

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: sort
+  name: Check Cargo.toml is sorted
+  description: 'Ensure Cargo.toml is sorted'
+  entry: cargo-sort -c -w
+  language: rust
+  types: [file, toml]
+  files: Cargo\.toml
+  pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -70,6 +70,22 @@ If you have a header to add open a PR, they are welcome.
 cargo install cargo-sort
 ```
 
+## pre-commit
+
+If you use [pre-commit](https://pre-commit.com/) in your project, you can add cargo-sort as hook by
+adding the following entry to your `.pre-commit0-config.yaml` configuration:
+
+```yaml
+repos:
+- repo: https://github.com/DevinR528/cargo-sort
+  rev: v1.0.4
+  hooks:
+  - id: cargo-sort
+```
+
+Please make sure to set `rev` to the latest tag of this repo as the tag shown here might not always
+be updated to the latest version.
+
 # Run
 
 Thanks to [dspicher](https://github.com/dspicher) for [issue #4](https://github.com/DevinR528/cargo-sort-ck/issues/4) you can now invoke `cargo sort` check as a cargo subcommand


### PR DESCRIPTION
This change adds a configuration for the [pre-commit](https://pre-commit.com) tool that allows to automatically checking various details of a project before completing a Git commit.

With this addition it's possible to use cargo-sort as a custom hook in other projects. The pre-commit tool will handle installation and execution, so it only needs this single file to work.

The main motivation is that I was asked in https://github.com/mozilla/grcov/pull/644 whether it's possible to somehow automate the check for a sorted Cargo.toml which should help in not getting the file back into an unsorted state again.﻿

### Todo

- [x] Maybe the pre-commit config should be mentioned in the README.md?
  - Added with the latest commit.
- [x] Eventually it's not always wanted to run with `-c -w` as arguments?
  - Removed to be consistent with invoking the CLI directly and allow users to pick the options they want.