### PR TITLE
Fix fmt crlf issue

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -9,7 +9,10 @@ on:
 jobs:
   check:
     name: Check
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -24,7 +24,3 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
-    - name: Run tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -246,6 +246,12 @@ mod test {
         let input = fs::read_to_string("examp/right.toml").unwrap();
         let mut toml = input.parse::<Document>().unwrap();
         fmt_toml(&mut toml, &Config::new());
+        #[cfg(target_os = "windows")]
+        assert_eq!(
+            input.replace("\r\n", "\n"),
+            toml.to_string_in_original_order().replace("\r\n", "\n")
+        );
+        #[cfg(not(target_os = "windows"))]
         assert_eq!(input, toml.to_string_in_original_order());
     }
 

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -285,6 +285,12 @@ mod test {
     fn sort_correct() {
         let input = fs::read_to_string("examp/right.toml").unwrap();
         let sorted = super::sort_toml(&input, MATCHER, true, &[]);
+        #[cfg(target_os = "windows")]
+        assert_eq!(
+            input.replace("\r\n", "\n"),
+            sorted.to_string_in_original_order().replace("\r\n", "\n")
+        );
+        #[cfg(not(target_os = "windows"))]
         assert_eq!(input, sorted.to_string_in_original_order());
         // println!("{}", sorted.to_string_in_original_order());
     }
@@ -301,11 +307,23 @@ mod test {
     fn sort_devfirst() {
         let input = fs::read_to_string("examp/reorder.toml").unwrap();
         let sorted = super::sort_toml(&input, MATCHER, true, &[]);
+        #[cfg(target_os = "windows")]
+        assert_eq!(
+            input.replace("\r\n", "\n"),
+            sorted.to_string_in_original_order().replace("\r\n", "\n")
+        );
+        #[cfg(not(target_os = "windows"))]
         assert_eq!(input, sorted.to_string_in_original_order());
         // println!("{}", sorted.to_string_in_original_order());
 
         let input = fs::read_to_string("examp/noreorder.toml").unwrap();
         let sorted = super::sort_toml(&input, MATCHER, true, &[]);
+        #[cfg(target_os = "windows")]
+        assert_eq!(
+            input.replace("\r\n", "\n"),
+            sorted.to_string_in_original_order().replace("\r\n", "\n")
+        );
+        #[cfg(not(target_os = "windows"))]
         assert_eq!(input, sorted.to_string_in_original_order());
         // println!("{}", sorted.to_string_in_original_order());
     }


### PR DESCRIPTION
Found an issue related to line endings when running `cargo sort` on Windows where the sorted `Cargo.toml` had format errors.

My `Cargo.toml`  looked something like this: 
```toml
[package]
name = "priv-test"
version = "0.1.0"
edition = "2021"
resolver = "2"

# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

[dependencies]
structopt = "0.3"
```
Notice the space around the comment. 
After the sorting pass,  the Windows line endings that looked like this:
```
resolver = "2"\n
\r\n
# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html\n
\r\n
[dependencies]\n
```
The issue came to light when the `fmt_table` was called because it was turning that first `\r\n` into a dangling `\r`.

## Bonus ?
I enabled the `Check`  job so it runs on Windows. Hopefully that's ok. 