### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,19 @@
-FROM ekidd/rust-musl-builder:latest as builder
-WORKDIR /home/rust/src
-COPY . .
-RUN cargo build --locked --release
-RUN mkdir -p build-out/
-RUN cp target/x86_64-unknown-linux-musl/release/cargo-sort build-out/
-RUN strip build-out/cargo-sort
+FROM lukemathwalker/cargo-chef:latest-rust-latest AS chef
+WORKDIR app
 
-FROM scratch
-WORKDIR /app
-COPY --from=builder /home/rust/src/build-out/cargo-sort .
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+COPY . .
+RUN cargo build --verbose --locked --release
+RUN strip /app/target/release/cargo-sort
+
+FROM debian:buster-slim AS runtime
+WORKDIR app
+COPY --from=builder /app/target/release/cargo-sort /usr/local/bin
 USER 1000:1000
-CMD ["./cargo-sort"]
+ENTRYPOINT ["cargo-sort"]


### PR DESCRIPTION
This PR updates Dockerfile to utilize [cargo-chef](https://github.com/LukeMathWalker/cargo-chef) and improve caching.

It also fixes the build errors happened in #48 due to [rust-musl-builder](https://github.com/emk/rust-musl-builder) being unmaintained. (See https://github.com/emk/rust-musl-builder/issues/147)

