### PR TITLE
Sort workspace dependencies

### DIFF
--- a/examp/workspace_deps.toml
+++ b/examp/workspace_deps.toml
@@ -1,0 +1,5 @@
+[workspace]
+
+[workspace.dependencies]
+b = "1"
+a = "1"

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -89,7 +89,7 @@ pub fn sort_toml(
 
                 gather_headings(table, headings, 1);
                 headings.sort();
-                sort_by_group(table);
+                sort_table(table, group);
             }
             Item::None => continue,
             _ => unreachable!("Top level toml must be tables"),


### PR DESCRIPTION
Part of the new workspace dependencies feature described here https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#inheriting-a-dependency-from-a-workspace

Fixes #54