### PR TITLE
feat: sort workspace dependencies

### DIFF
--- a/examp/workspace_dep.toml
+++ b/examp/workspace_dep.toml
@@ -1,0 +1,3 @@
+[workspace.dependencies]
+foo = "*"
+bar = "*"


### PR DESCRIPTION
The workspace manifest can specify dependencies that can be inherited by workspace members [1].

This commit adds support for sorting those dependencies.

[1] https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table