### PR TITLE
Add sorting for `workspace.dependencies` section

### DIFF
--- a/src/sort.rs
+++ b/src/sort.rs
@@ -14,7 +14,11 @@ pub struct Matcher<'a> {
 
 pub const MATCHER: Matcher<'_> = Matcher {
     heading: &["dependencies", "dev-dependencies", "build-dependencies"],
-    heading_key: &[("workspace", "members"), ("workspace", "exclude")],
+    heading_key: &[
+        ("workspace", "members"),
+        ("workspace", "exclude"),
+        ("workspace", "dependencies"),
+    ],
 };
 
 /// A state machine to track collection of headings.


### PR DESCRIPTION
Add sorting for `workspace.dependencies` section
https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table