### PR TITLE
Upgraded pipelines

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,11 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-
+        uses: actions/checkout@v4
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: |
             devinr528/cargo-sort

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,5 +19,3 @@ jobs:
         run: cargo fmt -- --check
       - name: Catch common mistakes
         run: cargo clippy
-      - name: Sort Cargo.toml
-        run: cargo install cargo-sort && cargo sort --grouped --check

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,21 +11,13 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        profile: minimal
-        override: true
-        components: rustfmt, clippy
-    - name: Check formatting
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: -- --check
-    - name: Catch common mistakes
-      uses: actions-rs/cargo@v1
-      with:
-        command: mean-clippy
-    - name: Sort Cargo.toml
-      run: cargo install cargo-sort && cargo sort -gc
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt, clippy
+      - name: Check formatting
+        run: cargo fmt -- --check
+      - name: Catch common mistakes
+        run: cargo clippy
+      - name: Sort Cargo.toml
+        run: cargo install cargo-sort && cargo sort --grouped --check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,10 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: taiki-e/create-gh-release-action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   upload-assets:
     strategy:
@@ -23,10 +23,10 @@ jobs:
           - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: cargo-sort
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_PROFILE_RELEASE_LTO: true
+          tar: unix
+          zip: windows
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -11,16 +11,12 @@ jobs:
     name: Check
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
-        override: true
-    - name: Run tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+      - name: Run tests
+        run: cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,10 @@ toml_edit = "0.21"
 [dev-dependencies]
 serde_json = "1"
 similar-asserts = "1.5.0"
-# The following is commented out for releases because of https://github.com/DevinR528/cargo-sort/issues/31 see also https://github.com/rust-lang/cargo/issues/8703
+
+# The following is commented out for releases because of
+# https://github.com/DevinR528/cargo-sort/issues/31
+# see also https://github.com/rust-lang/cargo/issues/8703
 
 # [[bin]]
 # name = "cargo-sort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "cargo-sort"
 version = "1.1.0"
-authors = ["Devin R <devin.ragotzy@gmail.com>", "Andronik Ordian <write@reusable.software>"]
+authors = [
+    "Devin R <devin.ragotzy@gmail.com>",
+    "Andronik Ordian <write@reusable.software>",
+]
 license = "MIT/Apache-2.0"
 description = "Check if tables and items in a .toml file are lexically sorted"
 repository = "https://github.com/DevinR528/cargo-sort"
@@ -25,10 +28,7 @@ toml_edit = "0.21"
 [dev-dependencies]
 serde_json = "1"
 similar-asserts = "1.5.0"
-
-# The following is commented out for releases because of
-# https://github.com/DevinR528/cargo-sort/issues/31
-# see also https://github.com/rust-lang/cargo/issues/8703
+# The following is commented out for releases because of https://github.com/DevinR528/cargo-sort/issues/31 see also https://github.com/rust-lang/cargo/issues/8703
 
 # [[bin]]
 # name = "cargo-sort"
@@ -43,3 +43,6 @@ similar-asserts = "1.5.0"
 # name = "fuzz"
 # path = "src/fuzz.rs"
 # required-features = ["fuzz"]
+
+[profile.release]
+lto = true


### PR DESCRIPTION
This is first part of: https://github.com/DevinR528/cargo-sort/pull/78

- [x] Upgraded version for plugins
- [x] Replaces use `actions-rs` to `dtolnay/rust-toolchain`