### PR TITLE
Add empty workspace to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,5 @@ similar-asserts = "1.5.0"
 
 [profile.release]
 lto = true
+
+[workspace]


### PR DESCRIPTION
This fixes an issue that arises when the package is installed with pre-commit into a cache directory that is itself a subdirectory of a Cargo workspace, making Cargo think it's a package that should have been a part of the parent workspace.

```
An unexpected error has occurred: CalledProcessError: command: ('/usr/bin/cargo', 'install', '--bins', '--root', '/home/user/project/.cache/pre-commit/repor869qha6/rustenv-system', '--path', '.')
return code: 101
stdout: (none)
stderr:
    warning: `/home/user/project/.cache/pre-commit/repor869qha6/.cargo/config` is deprecated in favor of `config.toml`
    note: if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`
    warning: `/home/user/project/.cache/pre-commit/repor869qha6/./.cargo/config` is deprecated in favor of `config.toml`
    note: if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`
    error: current package believes it's in a workspace when it's not:
    current:   /home/user/project/.cache/pre-commit/repor869qha6/Cargo.toml
    workspace: /home/user/project/Cargo.toml
    
    this may be fixable by adding `.cache/pre-commit/repor869qha6` to the `workspace.members` array of the manifest located at: /home/user/project/Cargo.toml
    Alternatively, to keep it out of the workspace, add the package to the `workspace.exclude` array, or add an empty `[workspace]` table to the package's manifest.
```