### PR TITLE
Fix #72: `--grouped` handling when reording the first entry in a group.

### DIFF
--- a/examp/grouped_reorder.toml
+++ b/examp/grouped_reorder.toml
@@ -1,0 +1,12 @@
+[package]
+name = "foobar"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+a = { workspace = true }
+c = { workspace = true }
+b = { workspace = true }
+
+e = { workspace = true }
+d = { workspace = true }

--- a/examp/grouped_reorder_output.toml
+++ b/examp/grouped_reorder_output.toml
@@ -1,0 +1,12 @@
+[package]
+name = "foobar"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+a = { workspace = true }
+b = { workspace = true }
+c = { workspace = true }
+
+d = { workspace = true }
+e = { workspace = true }


### PR DESCRIPTION
https://github.com/DevinR528/cargo-sort/issues/72

Currently cargo-sort is broken with `--grouped` for situations where the first entry in a group gets reordered within the group, such as the following example:

```toml
[package]
name = "foobar"
version = "0.1.0"
edition = "2021"

[dependencies]
a = { workspace = true }
b = { workspace = true }

d = { workspace = true }
c = { workspace = true }
```

Current behavior produces the following output:

```toml
[package]
name = "foobar"
version = "0.1.0"
edition = "2021"

[dependencies]
a = { workspace = true }
b = { workspace = true }
c = { workspace = true }

d = { workspace = true }
```

This is because the newline separating the groups is attached to the decor for `d`, and it stays with `d` even as `c` and `d` change places.

This doesn't apply to the example above, but it's also possible for this behavior to introduce non-idempotency since the new first item gets attached to the previous group and it may get resorted within that group the next time cargo-sort is run.

I added a test for the correct behavior.