### PR TITLE
sort keys such as [target.'cfg(target_os="linux")'.dependencies] 

### DIFF
--- a/examp/tun.sorted.toml
+++ b/examp/tun.sorted.toml
@@ -1,0 +1,98 @@
+[package]
+name = "tun"
+version = "0.7.19"
+edition = "2024"
+authors = ["meh. <meh@schizofreni.co>", "@ssrlive"]
+license = "WTFPL"
+description = "TUN device creation and handling."
+repository = "https://github.com/meh/rust-tun"
+keywords = ["tun", "network", "tunnel", "bindings"]
+# rust-version = "1.85"
+
+[package.metadata.docs.rs]
+all-features = true
+
+[lib]
+crate-type = ["staticlib", "lib"]
+
+[features]
+# default = ["async"]
+async = [
+    "tokio",
+    "futures-core",
+    "futures",
+    "tokio-util",
+    "wintun-bindings/async",
+]
+
+[dependencies]
+bytes = { version = "1" }
+cfg-if = "1"
+futures-core = { version = "0.3", optional = true }
+libc = { version = "0.2", features = ["extra_traits"] }
+log = "0.4"
+thiserror = "2"
+tokio = { version = "1", features = [
+    "net",
+    "macros",
+    "io-util",
+], optional = true }
+tokio-util = { version = "0.7", features = ["codec"], optional = true }
+
+[target.'cfg(any(target_os = "macos", target_os = "freebsd"))'.dependencies]
+abcd = "9"
+ipnet = "2"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+futures = { version = "0.3", optional = true }
+windows-sys = { version = "0.59", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Security_WinTrust",
+    "Win32_Security_Cryptography",
+    "Win32_System_Threading",
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_System_LibraryLoader",
+] }
+wintun-bindings = { version = "^0.7.7", features = [
+    "panic_on_unsent_packets",
+    "verify_binary_signature",
+    "async",
+    "enable_inner_logging",
+    "winreg",
+] }
+
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.30", features = ["ioctl"] }
+
+[build-dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[target.'cfg(unix)'.build-dependencies]
+abcde = { version = "0.30", features = ["edfg"] }
+
+[dev-dependencies]
+packet = "0.1"
+serde_json = "1"
+tokio = { version = "1", features = ["rt-multi-thread"] }
+
+[target.'cfg(target_os = "windows")'.dev-dependencies]
+ctrlc2 = { version = "3", features = ["tokio", "termination"] }
+env_logger = "0.11"
+futures = "0.3"
+
+[target.'cfg(unix)'.dev-dependencies]
+nix = { version = "0.30", features = ["ioctl"] }
+
+[[example]]
+name = "read-async"
+required-features = ["async"]
+
+[[example]]
+name = "read-async-codec"
+required-features = ["async"]
+
+[[example]]
+name = "ping-tun"
+required-features = ["async"]

--- a/examp/tun.toml
+++ b/examp/tun.toml
@@ -1,0 +1,98 @@
+[package]
+name = "tun"
+version = "0.7.19"
+edition = "2024"
+authors = ["meh. <meh@schizofreni.co>", "@ssrlive"]
+license = "WTFPL"
+description = "TUN device creation and handling."
+repository = "https://github.com/meh/rust-tun"
+keywords = ["tun", "network", "tunnel", "bindings"]
+# rust-version = "1.85"
+
+[package.metadata.docs.rs]
+all-features = true
+
+[lib]
+crate-type = ["staticlib", "lib"]
+
+[features]
+# default = ["async"]
+async = [
+    "tokio",
+    "futures-core",
+    "futures",
+    "tokio-util",
+    "wintun-bindings/async",
+]
+
+[dependencies]
+bytes = { version = "1" }
+cfg-if = "1"
+futures-core = { version = "0.3", optional = true }
+libc = { version = "0.2", features = ["extra_traits"] }
+log = "0.4"
+thiserror = "2"
+tokio = { version = "1", features = [
+    "net",
+    "macros",
+    "io-util",
+], optional = true }
+tokio-util = { version = "0.7", features = ["codec"], optional = true }
+
+[target.'cfg(any(target_os = "macos", target_os = "freebsd"))'.dependencies]
+ipnet = "2"
+abcd = "9"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = { version = "0.59", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Security_WinTrust",
+    "Win32_Security_Cryptography",
+    "Win32_System_Threading",
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_System_LibraryLoader",
+] }
+wintun-bindings = { version = "^0.7.7", features = [
+    "panic_on_unsent_packets",
+    "verify_binary_signature",
+    "async",
+    "enable_inner_logging",
+    "winreg",
+] }
+futures = { version = "0.3", optional = true }
+
+[dev-dependencies]
+packet = "0.1"
+serde_json = "1"
+tokio = { version = "1", features = ["rt-multi-thread"] }
+
+[[example]]
+name = "read-async"
+required-features = ["async"]
+
+[[example]]
+name = "read-async-codec"
+required-features = ["async"]
+
+[[example]]
+name = "ping-tun"
+required-features = ["async"]
+
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.30", features = ["ioctl"] }
+
+[target.'cfg(unix)'.dev-dependencies]
+nix = { version = "0.30", features = ["ioctl"] }
+
+[target.'cfg(target_os = "windows")'.dev-dependencies]
+ctrlc2 = { version = "3", features = ["tokio", "termination"] }
+env_logger = "0.11"
+futures = "0.3"
+
+[target.'cfg(unix)'.build-dependencies]
+abcde = { version = "0.30", features = ["edfg"] }
+
+[build-dependencies]
+serde_json = "1"
+serde = { version = "1", features = ["derive"] }

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -7,6 +7,17 @@ const NEWLINE_PATTERN: &str = "\r\n";
 #[cfg(not(target_os = "windows"))]
 const NEWLINE_PATTERN: &str = "\n";
 
+pub(crate) const DEF_TABLE_ORDER: &[&str] = &[
+    "package",
+    "workspace",
+    "lib",
+    "bin",
+    "features",
+    "dependencies",
+    "build-dependencies",
+    "dev-dependencies",
+];
+
 /// The config file for formatting toml after sorting.
 ///
 /// Use the `FromStr` to create a config from a string.
@@ -98,16 +109,7 @@ impl Config {
             key_value_newlines: true,
             allowed_blank_lines: 1,
             crlf: false,
-            table_order: [
-                "package",
-                "features",
-                "dependencies",
-                "build-dependencies",
-                "dev-dependencies",
-            ]
-            .iter()
-            .map(|s| (*s).to_owned())
-            .collect(),
+            table_order: DEF_TABLE_ORDER.iter().map(|s| (*s).to_owned()).collect(),
         }
     }
 }
@@ -165,11 +167,15 @@ impl FromStr for Config {
             table_order: toml
                 .get("table_order")
                 .and_then(toml_edit::Item::as_array)
-                .into_iter()
-                .flatten()
-                .filter_map(|v| v.as_str())
-                .map(|s| s.to_string())
-                .collect(),
+                .map_or(
+                    DEF_TABLE_ORDER.iter().map(|s| (*s).to_owned()).collect(),
+                    |arr| {
+                        arr.into_iter()
+                            .filter_map(|v| v.as_str())
+                            .map(|s| s.to_string())
+                            .collect()
+                    },
+                ),
         })
     }
 }

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -90,7 +90,7 @@ pub fn sort_toml(
     let mut first_table = None;
     let mut heading_order: BTreeMap<_, Vec<Heading>> = BTreeMap::new();
     for (idx, (head, item)) in toml.as_table_mut().iter_mut().enumerate() {
-        let mut target_tables = BTreeMap::new();
+        let mut target_tables: TargetTablePaths = BTreeMap::new();
         let item_key = head.get();
         if item_key == TARGET {
             if let Some(table) = item.as_table() {
@@ -388,12 +388,12 @@ fn sort_by_ordering(
         });
 
         if !matches.is_empty() {
-            for &(key, to_sort_headings) in &matches {
+            for &((_, key), to_sort_headings) in &matches {
                 let mut to_sort_headings = to_sort_headings
                     .iter()
                     .filter_map(|h| {
                         if let Heading::Complete(segs) = h {
-                            if key.1 == TARGET {
+                            if key == TARGET {
                                 // Get rid of the items that do not contain the heading
                                 if segs.last() == Some(heading) {
                                     return Some(h);
@@ -407,7 +407,7 @@ fn sort_by_ordering(
                     .collect::<Vec<_>>();
                 to_sort_headings.sort_by_key(|h| {
                     if let Heading::Complete(segs) = h {
-                        if key.1 == TARGET {
+                        if key == TARGET {
                             // Sort the headings by the segments in reverse order
                             segs.iter().rev().cloned().collect::<Vec<_>>().join(".")
                         } else {

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -476,6 +476,19 @@ mod test {
     }
 
     #[test]
+    fn toml_combined_key_check() {
+        let input = fs::read_to_string("examp/tun.toml").unwrap();
+        let expected = fs::read_to_string("examp/tun.sorted.toml").unwrap();
+        let o = crate::fmt::DEF_TABLE_ORDER
+            .iter()
+            .map(|s| (*s).to_owned())
+            .collect::<Vec<_>>();
+        let sorted = super::sort_toml(&input, MATCHER, false, &o);
+
+        assert_eq(expected, sorted);
+    }
+
+    #[test]
     fn toml_workspace_deps_edit_check() {
         let input = fs::read_to_string("examp/workspace_deps.toml").unwrap();
         let expected = fs::read_to_string("examp/workspace_deps.sorted.toml").unwrap();

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -9,16 +9,16 @@ const TARGET: &str = "target";
 /// Stores the paths of target tables in a BTreeMap, the data structure looks like:
 /// ```plain
 /// target_tables: {
-/// 	"build-dependencies": [],
-/// 	"dependencies": [
-/// 		["target", "cfg(any(target_os = \"macos\", target_os = \"freebsd\"))", "dependencies"],
-/// 		["target", "cfg(target_os = \"windows\")", "dependencies"],
-/// 		["target", "cfg(unix)", "dependencies"]
-/// 	],
-/// 	"dev-dependencies": [
-/// 		["target", "cfg(target_os = \"windows\")", "dev-dependencies"],
-/// 		["target", "cfg(unix)", "dev-dependencies"]
-/// 	]
+///     "build-dependencies": [],
+///     "dependencies": [
+///         ["target", "cfg(any(target_os = \"macos\", target_os = \"freebsd\"))", "dependencies"],
+///         ["target", "cfg(target_os = \"windows\")", "dependencies"],
+///         ["target", "cfg(unix)", "dependencies"]
+///     ],
+///     "dev-dependencies": [
+///         ["target", "cfg(target_os = \"windows\")", "dev-dependencies"],
+///         ["target", "cfg(unix)", "dev-dependencies"]
+///     ]
 /// }
 /// ```
 type TargetTablePaths = BTreeMap<String, Vec<Vec<String>>>;
@@ -392,12 +392,12 @@ fn sort_by_ordering(
 
         if !matches.is_empty() {
             for &(key, to_sort_headings) in &matches {
-                // Get rid of the items that do not contain the heading
                 let mut to_sort_headings = to_sort_headings
                     .iter()
                     .filter_map(|h| {
                         if let Heading::Complete(segs) = h {
                             if key.1 == TARGET {
+                                // Get rid of the items that do not contain the heading
                                 if segs.last() == Some(heading) {
                                     return Some(h);
                                 }
@@ -408,10 +408,10 @@ fn sort_by_ordering(
                         None
                     })
                     .collect::<Vec<_>>();
-                // Sort the headings by the segments in reverse order
                 to_sort_headings.sort_by_key(|h| {
                     if let Heading::Complete(segs) = h {
                         if key.1 == TARGET {
+                            // Sort the headings by the segments in reverse order
                             segs.iter().rev().cloned().collect::<Vec<_>>().join(".")
                         } else {
                             segs.iter().cloned().collect::<Vec<_>>().join(".")
@@ -489,10 +489,8 @@ mod test {
     fn toml_combined_key_check() {
         let input = fs::read_to_string("examp/tun.toml").unwrap();
         let expected = fs::read_to_string("examp/tun.sorted.toml").unwrap();
-        let o = crate::fmt::DEF_TABLE_ORDER
-            .iter()
-            .map(|s| (*s).to_owned())
-            .collect::<Vec<_>>();
+        let o = crate::fmt::DEF_TABLE_ORDER;
+        let o = o.iter().map(|s| (*s).to_owned()).collect::<Vec<_>>();
         let sorted = super::sort_toml(&input, MATCHER, false, &o);
 
         assert_eq(expected, sorted);

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -205,9 +205,11 @@ fn sort_table(table: &mut Table, group: bool, target_tables: &TargetTablePaths) 
 }
 
 fn sort_table_by_path(table: &mut Table, path: &[String]) {
-    if path.is_empty() {
+    let Some(first) = path.first() else {
         table.sort_values();
-    } else if let Some(Item::Table(inner_table)) = table.get_mut(&path[0]) {
+        return;
+    };
+    if let Some(Item::Table(inner_table)) = table.get_mut(first) {
         sort_table_by_path(inner_table, &path[1..]);
     }
 }

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -78,7 +78,7 @@ pub fn sort_toml(
                             sort_array(arr);
                         }
                         Item::Table(table) => {
-                            sort_table(table, group, &BTreeMap::new());
+                            sort_table(table, group);
                         }
                         _ => {}
                     }
@@ -132,7 +132,8 @@ pub fn sort_toml(
 
                 gather_headings(table, headings, 1);
                 headings.sort();
-                sort_table(table, group, &target_tables);
+                sort_table(table, group);
+                sort_nested_table(table, &target_tables);
             }
             Item::None => continue,
             _ => {}
@@ -187,20 +188,22 @@ fn sort_array(arr: &mut Array) {
     arr.set_trailing_comma(trailing_comma);
 }
 
-fn sort_table(table: &mut Table, group: bool, target_tables: &TargetTablePaths) {
+fn sort_table(table: &mut Table, group: bool) {
     if group {
         sort_by_group(table);
-    } else if !target_tables.is_empty() {
-        // The `table` name must be `target`
-        for (_key, paths) in target_tables {
-            for path in paths {
-                if path.len() > 1 {
-                    sort_table_by_path(table, &path[1..]);
-                }
-            }
-        }
     } else {
         table.sort_values();
+    }
+}
+
+fn sort_nested_table(table: &mut Table, target_tables: &TargetTablePaths) {
+    // The `table` name must be `target`
+    for (_key, paths) in target_tables {
+        for path in paths {
+            if path.len() > 1 {
+                sort_table_by_path(table, &path[1..]);
+            }
+        }
     }
 }
 

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -391,13 +391,17 @@ fn sort_by_ordering(
         });
 
         if !matches.is_empty() {
-            for &(_k, to_sort_headings) in &matches {
+            for &(key, to_sort_headings) in &matches {
                 // Get rid of the items that do not contain the heading
                 let mut to_sort_headings = to_sort_headings
                     .iter()
                     .filter_map(|h| {
                         if let Heading::Complete(segs) = h {
-                            if segs.last() == Some(heading) {
+                            if key.1 == TARGET {
+                                if segs.last() == Some(heading) {
+                                    return Some(h);
+                                }
+                            } else {
                                 return Some(h);
                             }
                         }
@@ -407,7 +411,11 @@ fn sort_by_ordering(
                 // Sort the headings by the segments in reverse order
                 to_sort_headings.sort_by_key(|h| {
                     if let Heading::Complete(segs) = h {
-                        segs.iter().rev().cloned().collect::<Vec<_>>().join(".")
+                        if key.1 == TARGET {
+                            segs.iter().rev().cloned().collect::<Vec<_>>().join(".")
+                        } else {
+                            segs.iter().cloned().collect::<Vec<_>>().join(".")
+                        }
                     } else {
                         String::new()
                     }


### PR DESCRIPTION
And let more important sections participate in high priority sorting.