### PR TITLE
test: add regression test for multi-line comments

### DIFF
--- a/examp/comments.sorted.toml
+++ b/examp/comments.sorted.toml
@@ -1,27 +1,27 @@
 [dependencies]
-actix-web = "2.0"               # Actix web
-actix-rt = "1.1"                # Actix runtime
 actix-identity = "0.2"          # Identity
+actix-rt = "1.1"                # Actix runtime
+actix-web = "2.0"               # Actix web
+derive_more = "0.99"
+env_logger = "0.7"              # logging
+futures = "0.3"                 # async
+jsonschema = "0.3"              # JSON schema
+lazy_static = "1.4"             # runtime const evaluation
+log = "0.4"                     # logging
+rand = "0.7.3"                  # random value generator
 serde = "1.0"                   # serialization
 serde_json = "1.0"              # serialization for JSON
-log = "0.4"                     # logging
-env_logger = "0.7"              # logging
-derive_more = "0.99"
-futures = "0.3"                 # async
-lazy_static = "1.4"             # runtime const evaluation
-jsonschema = "0.3"              # JSON schema
-rand = "0.7.3"                  # random value generator
 uuid = { version = "0.8", features = ["v4"] } # UUID
 
 # This is a multi-line comment above a group.
 # It should remain a multi-line comment after sorting.
 argonautica = "0.2"  # argon2 password hashing
+hex = "0.4.2"        # for encoding the bytes from hmac to a postgres TEXT field
 hmac = "0.9.0"       # for api token hashing
 sha2 = "0.9.1"       # for api token hashing
-hex = "0.4.2"        # for encoding the bytes from hmac to a postgres TEXT field
 
-diesel = { version = "1.4.4", features = ["postgres", "chrono", "r2d2", "serde_json"] } # Database
 chrono = { version = "0.4.11", features = ["serde"] } # time
+diesel = { version = "1.4.4", features = ["postgres", "chrono", "r2d2", "serde_json"] } # Database
+diesel_migrations = "1.4"       # Embedding database migration
 dotenv = "0.15.0"                                     # environment variables
 r2d2 = "0.8"                                          # Database pooling
-diesel_migrations = "1.4"       # Embedding database migration

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -351,6 +351,14 @@ mod test {
     }
 
     #[test]
+    fn sort_comments() {
+        let input = fs::read_to_string("examp/comments.toml").unwrap();
+        let expected = fs::read_to_string("examp/comments.sorted.toml").unwrap();
+        let sorted = super::sort_toml(&input, MATCHER, true, &[]);
+        assert_eq(expected, sorted);
+    }
+
+    #[test]
     fn sort_tables() {
         let input = fs::read_to_string("examp/fend.toml").unwrap();
         let sorted = super::sort_toml(&input, MATCHER, true, &[]);


### PR DESCRIPTION
This adds a regression test to ensure we retain multi-line comments above groups and generally don't mess with comments.