### PR TITLE
fix: don't re-wrap multiline comments

### DIFF
--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -362,7 +362,7 @@ mod test {
             "[package]\r\nname = \"priv-test\"\r\nversion = \"0.1.0\"\r\nedition = \"2021\"\r\nresolver = \"2\"\r\n\r\n# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html\r\n\r\n[dependencies]\r\nstructopt = \"0.3\"\r\n",
         );
         let expected = String::from(
-            "[package]\nname = \"priv-test\"\nversion = \"0.1.0\"\nedition = \"2021\"\nresolver = \"2\"\n# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html\n\n[dependencies]\nstructopt = \"0.3\"\n",
+            "[package]\nname = \"priv-test\"\nversion = \"0.1.0\"\nedition = \"2021\"\nresolver = \"2\"\n\n# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html\n\n[dependencies]\nstructopt = \"0.3\"\n",
         );
         let mut toml = input.parse::<DocumentMut>().unwrap();
         fmt_toml(&mut toml, &Config::new());


### PR DESCRIPTION
Currently, the logic for allowing blank lines replaces all newlines within the decor with empty strings, regardless as to whether the line is empty or not. This messes up multi-line comments.

To fix this, we switch the search-replace to an iterative approach.