### PR TITLE
fix: retain comments within arrays

### DIFF
--- a/examp/clippy.fmt.toml
+++ b/examp/clippy.fmt.toml
@@ -6,7 +6,7 @@ authors = [
     "Andre Bogus <bogusandre@gmail.com>",
     "Georg Brandl <georg@python.org>",
     "Martin Carton <cartonmartin@gmail.com>",
-    "Oliver Schneider <clippy-iethah7aipeen8neex1a@oli-obk.de>"
+    "Oliver Schneider <clippy-iethah7aipeen8neex1a@oli-obk.de>",
 ]
 description = "A bunch of helpful lints to avoid common pitfalls in Rust"
 repository = "https://github.com/rust-lang/rust-clippy"
@@ -36,7 +36,7 @@ clippy_lints = { version = "0.0.212", path = "clippy_lints" }
 # end automatic update
 regex = "1"
 semver = "0.9"
-rustc_tools_util = { version = "0.2.0", path = "rustc_tools_util"}
+rustc_tools_util = { version = "0.2.0", path = "rustc_tools_util" }
 git2 = { version = "0.12", optional = true }
 tempfile = { version = "3.1.0", optional = true }
 lazy_static = "1.0"
@@ -56,20 +56,14 @@ derive-new = "0.5"
 rustc-workspace-hack = "1.0.0"
 
 [build-dependencies]
-rustc_tools_util = { version = "0.2.0", path = "rustc_tools_util"}
+rustc_tools_util = { version = "0.2.0", path = "rustc_tools_util" }
 
 [features]
 deny-warnings = []
 integration = [
-
-
-
-
     # A feature comment that makes this line very long.
     "git2",
-
-
-    "tempfile", # Here is another comment.
-
-    "abc"
+    "tempfile",
+    # Here is another comment.
+    "abc",
 ]

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -331,9 +331,8 @@ pub fn fmt_toml(toml: &mut DocumentMut, config: &Config) {
 mod test {
     use std::fs;
 
-    use similar_asserts::assert_eq;
-
     use super::{fmt_toml, Config, DocumentMut};
+    use crate::test_utils::assert_eq;
 
     #[test]
     fn toml_fmt_check() {
@@ -349,10 +348,7 @@ mod test {
         let input = fs::read_to_string("examp/right.toml").unwrap();
         let mut toml = input.parse::<DocumentMut>().unwrap();
         fmt_toml(&mut toml, &Config::new());
-        #[cfg(target_os = "windows")]
-        assert_eq!(input.replace("\r\n", "\n"), toml.to_string().replace("\r\n", "\n"));
-        #[cfg(not(target_os = "windows"))]
-        assert_eq!(input, toml.to_string());
+        assert_eq(input, toml);
     }
 
     #[cfg(target_os = "windows")]
@@ -366,7 +362,7 @@ mod test {
         );
         let mut toml = input.parse::<DocumentMut>().unwrap();
         fmt_toml(&mut toml, &Config::new());
-        assert_eq!(expected, toml.to_string());
+        similar_asserts::assert_eq!(expected, toml.to_string());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,8 @@ use toml_edit::{DocumentMut, Item};
 
 mod fmt;
 mod sort;
+#[cfg(test)]
+mod test_utils;
 
 const EXTRA_HELP: &str = "\
     NOTE: formatting is applied after the check for sorting so \

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -317,9 +317,8 @@ fn walk_tables_set_position(table: &mut Table, idx: &mut usize) {
 mod test {
     use std::fs;
 
-    use similar_asserts::assert_eq;
-
     use super::MATCHER;
+    use crate::test_utils::assert_eq;
 
     #[test]
     fn toml_edit_check() {
@@ -395,16 +394,5 @@ mod test {
             ],
         );
         assert_ne!(input, sorted.to_string());
-    }
-
-    fn assert_eq<L: ToString, R: ToString>(left: L, right: R) {
-        let left = left.to_string();
-        let right = right.to_string();
-
-        #[cfg(windows)]
-        assert_eq!(left.replace("\r\n", "\n"), right.replace("\r\n", "\n"));
-
-        #[cfg(not(windows))]
-        assert_eq!(left, right);
     }
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,0 +1,10 @@
+pub fn assert_eq<L: ToString, R: ToString>(left: L, right: R) {
+    let left = left.to_string();
+    let right = right.to_string();
+
+    #[cfg(windows)]
+    similar_asserts::assert_eq!(left.replace("\r\n", "\n"), right.replace("\r\n", "\n"));
+
+    #[cfg(not(windows))]
+    similar_asserts::assert_eq!(left, right);
+}


### PR DESCRIPTION
This PR fixes comments within arrays. Comments are syntactically "prefix decors" of the array elements. In order to format them consistently, we put them on a dedicated line above the element,